### PR TITLE
[TER-246] Fix barcode loading issue

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         <activity
             android:name="com.safetyculture.utils.zxing.CaptureActivity"
             android:screenOrientation="landscape"
-            android:configChanges="orientation|keyboardHidden"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             android:windowSoftInputMode="stateAlwaysHidden"/>
     </application>

--- a/src/main/java/com/safetyculture/utils/zxing/CaptureActivity.java
+++ b/src/main/java/com/safetyculture/utils/zxing/CaptureActivity.java
@@ -42,7 +42,6 @@ import com.safetyculture.utils.zxing.camera.CameraManager;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.Map;
 
 /**
@@ -54,21 +53,9 @@ import java.util.Map;
  */
 public final class CaptureActivity extends Activity implements SurfaceHolder.Callback
 {
-
 	private static final String TAG = CaptureActivity.class.getSimpleName();
 
 	private static final long DEFAULT_INTENT_RESULT_DURATION_MS = 1500L;
-	private static final long BULK_MODE_SCAN_DELAY_MS = 1000L;
-
-	private static final String[] ZXING_URLS = {"http://zxing.appspot.com/scan", "zxing://scan/"};
-
-	public static final int HISTORY_REQUEST_CODE = 0x0000bacc;
-
-	private static final Collection<ResultMetadataType> DISPLAYABLE_METADATA_TYPES =
-			EnumSet.of(ResultMetadataType.ISSUE_NUMBER,
-					ResultMetadataType.SUGGESTED_PRICE,
-					ResultMetadataType.ERROR_CORRECTION_LEVEL,
-					ResultMetadataType.POSSIBLE_COUNTRY);
 
 	private CameraManager cameraManager;
 	private CaptureActivityHandler handler;
@@ -104,6 +91,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 	{
 		super.onCreate(icicle);
 
+		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
 		Window window = getWindow();
 		window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 		setContentView(R.layout.zxinglib_capture);
@@ -124,18 +112,17 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 		// off screen.
 		cameraManager = new CameraManager(getApplication());
 
-		viewfinderView = (ViewfinderView) findViewById(R.id.zxinglib_viewfinder_view);
+		viewfinderView = findViewById(R.id.zxinglib_viewfinder_view);
 		viewfinderView.setCameraManager(cameraManager);
 
-		statusView = (TextView) findViewById(R.id.zxinglib_status_view);
+		statusView = findViewById(R.id.zxinglib_status_view);
 
 		handler = null;
 		lastResult = null;
 
-		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
 		resetStatusView();
 
-		SurfaceView surfaceView = (SurfaceView) findViewById(R.id.zxinglib_preview_view);
+		SurfaceView surfaceView = findViewById(R.id.zxinglib_preview_view);
 		SurfaceHolder surfaceHolder = surfaceView.getHolder();
 		if(hasSurface)
 		{
@@ -208,7 +195,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 		//historyManager = null; // Keep for onActivityResult
 		if(!hasSurface)
 		{
-			SurfaceView surfaceView = (SurfaceView) findViewById(R.id.zxinglib_preview_view);
+			SurfaceView surfaceView = findViewById(R.id.zxinglib_preview_view);
 			SurfaceHolder surfaceHolder = surfaceView.getHolder();
 			surfaceHolder.removeCallback(this);
 		}


### PR DESCRIPTION
JIRA - https://safetyculture.atlassian.net/browse/TER-246

There was an issue when the user tapped on the barcode in the auditing link. It could take up to 30 secs to load the barcode reader. This delay was seen on Samsung devices.

On further investigation, the method invocation of `setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);` inside the `onResume()` of `CaptureActivity` caused the activity to be relaunched again and again and again. In a best case, it would happen for around 10 secs and in the worst case, it went on for 30 secs.

In the documentation for `setRequestedOrientation(int)`, it is mentioned `Change the desired orientation of this activity. If the activity is currently in the foreground or otherwise impacting the screen orientation, the screen will immediately be changed (possibly causing the activity to be restarted). Otherwise, this will be used the next time the activity is visible.`. 

The fix has been to move that call into `onCreate` and include the `screenSize` as a value for the attribute `android:configChanges` as suggested in this comment - https://stackoverflow.com/questions/38856908#comment65078237_38856908